### PR TITLE
Use Jekyll GitHub context

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,3 @@
-description: Cal-ITP's home for technical documentation
-
 github:
   is_project_page: true
 
@@ -9,8 +7,6 @@ locale: en
 
 plugins:
   - jekyll-seo-tag
-
-tagline: Cal-ITP's home for technical documentation
 
 theme:
   color: "#157878"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,13 +29,7 @@
     <header class="page-header" role="banner">
       <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
       <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
-      {% if site.github.is_project_page %}
-        <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
-      {% endif %}
-      {% if site.show_downloads %}
-        <a href="{{ site.github.zip_url }}" class="btn">Download .zip</a>
-        <a href="{{ site.github.tar_url }}" class="btn">Download .tar.gz</a>
-      {% endif %}
+      <a href="{{ site.github.owner_url }}" class="btn">Cal-ITP on GitHub</a>
     </header>
 
     <main id="content" class="main-content" role="main">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,8 +27,8 @@
     <a id="skip-to-content" href="#content">Skip to the content.</a>
 
     <header class="page-header" role="banner">
-      <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
-      <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
+      <h1 class="project-name">{{ page.title | default: site.title }}</h1>
+      <h2 class="project-tagline">{{ page.description | default: site.github.project_tagline }}</h2>
       <a href="{{ site.github.owner_url }}" class="btn">Cal-ITP on GitHub</a>
     </header>
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-title: Cal-ITP Documentation
 ---
 
 <h2>Browse our projects</h2>


### PR DESCRIPTION
Jekyll makes available a `site.github` context with information about this repository from GitHub's API. This PR:

1. Makes the homepage button point to Cal-ITP's GitHub org home; multiple links to this repo are still available below the fold
2. Removes some hardcoded configuration using data from GitHub instead
3. Removes some unused homepage buttons