### PR TITLE
Stabilize data sort order in pipeline

### DIFF
--- a/_includes/repos/index.html
+++ b/_includes/repos/index.html
@@ -1,5 +1,6 @@
 <div class="repo-list">
-{% for repo in site.data.repos %}
+{% assign repos = site.data.repos | sort: "updated_at" | reverse %}
+{% for repo in repos %}
     {% include repos/record.html repo=repo %}
 {% endfor %}
 </div>

--- a/bin/repos/sort.sh
+++ b/bin/repos/sort.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -eu
 
-cat | jq "sort_by(.pushed_at) | reverse"
+cat | jq "sort_by(.name | ascii_downcase)"


### PR DESCRIPTION
Before this PR, we sorted data in the pipeline by `pushed_at`, resulting in a large number of adds/deletes per commit, making at-a-glance change tracking more difficult.

Sorting by name in the pipeline means each commit will more clearly show the actual changes in data from the previous commit
as the order of repos should be more stable.

The sorting was pushed into the UI layer to make data obtained via the GitHub Action cleaner, so no change was made to how the repositories are displayed on the homepage. These are still ordered with most recently updated first. 

